### PR TITLE
feat: AgentCore Runtime に Notion API キーを SSM 経由で渡す

### DIFF
--- a/infra/stacks/operation_agent_stack.py
+++ b/infra/stacks/operation_agent_stack.py
@@ -71,6 +71,19 @@ class OperationAgentStack(cdk.Stack):
             )
         )
 
+        # Notion API キー（SSM SecureString）読み取り権限
+        notion_param = f"/operation-agent/{env_name}/notion/api-key"
+        agent_role.add_to_policy(
+            iam.PolicyStatement(
+                sid="SsmGetNotionApiKey",
+                effect=iam.Effect.ALLOW,
+                actions=["ssm:GetParameter"],
+                resources=[
+                    f"arn:aws:ssm:{REGION}:{self.account}:parameter{notion_param}",
+                ],
+            )
+        )
+
         # S3 セッションバケット読み書き権限
         agent_role.add_to_policy(
             iam.PolicyStatement(
@@ -113,5 +126,6 @@ class OperationAgentStack(cdk.Stack):
                 "OTEL_EXPORTER_OTLP_ENDPOINT": f"https://xray.{REGION}.amazonaws.com",
                 "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                 "DIAG_SESSION_BUCKET": session_bucket.bucket_name,
+                "DIAG_NOTION_API_TOKEN_PARAM": notion_param,
             },
         )

--- a/src/diagnosis/__main__.py
+++ b/src/diagnosis/__main__.py
@@ -1,10 +1,28 @@
 """AgentCore Runtime エントリポイント — HTTP サーバとして動作する"""
 
+import os
+
+import boto3
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 
 from diagnosis.agent import create_agent
 from diagnosis.telemetry import setup_telemetry
 
+
+def _resolve_ssm_secrets() -> None:
+    """SSM SecureString からシークレットを取得して環境変数にセットする。
+
+    DIAG_NOTION_API_TOKEN_PARAM が設定されている場合、SSM から値を取得して
+    DIAG_NOTION_API_TOKEN に設定する。
+    """
+    param_name = os.environ.get("DIAG_NOTION_API_TOKEN_PARAM")
+    if param_name:
+        ssm = boto3.client("ssm", region_name=os.environ.get("AWS_REGION", "ap-northeast-1"))
+        resp = ssm.get_parameter(Name=param_name, WithDecryption=True)
+        os.environ["DIAG_NOTION_API_TOKEN"] = resp["Parameter"]["Value"]
+
+
+_resolve_ssm_secrets()
 setup_telemetry()
 
 app = BedrockAgentCoreApp()

--- a/tests/diagnosis/test_server.py
+++ b/tests/diagnosis/test_server.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, patch
 
 
@@ -64,3 +65,35 @@ def test_handle_passes_none_session_id_when_absent():
         _handle({"prompt": "test"})
 
     mock_create.assert_called_once_with(session_id=None)
+
+
+def test_resolve_ssm_secrets_sets_env_when_param_set(monkeypatch):
+    """DIAG_NOTION_API_TOKEN_PARAM が設定されている場合、SSM から取得して DIAG_NOTION_API_TOKEN をセットする"""
+    from diagnosis.__main__ import _resolve_ssm_secrets  # import before patching
+
+    monkeypatch.setenv("DIAG_NOTION_API_TOKEN_PARAM", "/operation-agent/dev/notion/api-key")
+    monkeypatch.delenv("DIAG_NOTION_API_TOKEN", raising=False)
+
+    mock_ssm = MagicMock()
+    mock_ssm.get_parameter.return_value = {"Parameter": {"Value": "secret_test_token"}}
+
+    with patch("diagnosis.__main__.boto3") as mock_boto3:
+        mock_boto3.client.return_value = mock_ssm
+        _resolve_ssm_secrets()
+
+    assert os.environ.get("DIAG_NOTION_API_TOKEN") == "secret_test_token"
+    mock_ssm.get_parameter.assert_called_once_with(Name="/operation-agent/dev/notion/api-key", WithDecryption=True)
+
+
+def test_resolve_ssm_secrets_noop_when_param_not_set(monkeypatch):
+    """DIAG_NOTION_API_TOKEN_PARAM が未設定の場合、SSM を呼ばない"""
+    from diagnosis.__main__ import _resolve_ssm_secrets  # import before patching
+
+    monkeypatch.delenv("DIAG_NOTION_API_TOKEN_PARAM", raising=False)
+    monkeypatch.delenv("DIAG_NOTION_API_TOKEN", raising=False)
+
+    with patch("diagnosis.__main__.boto3") as mock_boto3:
+        _resolve_ssm_secrets()
+
+    mock_boto3.client.assert_not_called()
+    assert os.environ.get("DIAG_NOTION_API_TOKEN") is None

--- a/tests/infra/test_operation_agent_stack.py
+++ b/tests/infra/test_operation_agent_stack.py
@@ -128,3 +128,37 @@ def test_agentcore_runtime_has_session_bucket_env():
         "AWS::BedrockAgentCore::Runtime",
         {"EnvironmentVariables": Match.object_like({"DIAG_SESSION_BUCKET": Match.any_value()})},
     )
+
+
+def test_agentcore_runtime_has_notion_api_token_param_env():
+    template = Template.from_stack(make_stack())
+    template.has_resource_properties(
+        "AWS::BedrockAgentCore::Runtime",
+        {
+            "EnvironmentVariables": Match.object_like(
+                {"DIAG_NOTION_API_TOKEN_PARAM": "/operation-agent/dev/notion/api-key"}
+            )
+        },
+    )
+
+
+def test_iam_role_has_ssm_notion_permission():
+    template = Template.from_stack(make_stack())
+    template.has_resource_properties(
+        "AWS::IAM::Policy",
+        {
+            "PolicyDocument": {
+                "Statement": Match.array_with(
+                    [
+                        Match.object_like(
+                            {
+                                "Sid": "SsmGetNotionApiKey",
+                                "Action": "ssm:GetParameter",
+                                "Effect": "Allow",
+                            }
+                        )
+                    ]
+                )
+            }
+        },
+    )


### PR DESCRIPTION
## Summary

- `_resolve_ssm_secrets()` を `src/diagnosis/__main__.py` に追加。コンテナ起動時に `DIAG_NOTION_API_TOKEN_PARAM` で指定された SSM SecureString からトークンを取得し `DIAG_NOTION_API_TOKEN` にセットする（Slack Bot と同方式）
- `OperationAgentStack` に `ssm:GetParameter` IAM 権限と `DIAG_NOTION_API_TOKEN_PARAM` 環境変数を追加

## 事前準備

デプロイ前に SSM パラメータを手動作成:
```bash
aws ssm put-parameter \
  --name "/operation-agent/dev/notion/api-key" \
  --value "secret_xxxxxxxxxxxx" \
  --type SecureString
```

## Test plan

- [x] `test_resolve_ssm_secrets_sets_env_when_param_set` — SSM 取得 → env var セット
- [x] `test_resolve_ssm_secrets_noop_when_param_not_set` — パラメータ未設定時は SSM を呼ばない
- [x] `test_agentcore_runtime_has_notion_api_token_param_env` — CDK env var 確認
- [x] `test_iam_role_has_ssm_notion_permission` — IAM 権限確認
- [x] 全 92 テスト通過

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)