### PR TITLE
feat: 現在時刻を取得するget_current_timeツールを追加する

### DIFF
--- a/src/diagnosis/agent.py
+++ b/src/diagnosis/agent.py
@@ -4,7 +4,7 @@ from strands.session.s3_session_manager import S3SessionManager
 
 from diagnosis.config import DiagnosisConfig
 from diagnosis.prompts import SYSTEM_PROMPT
-from diagnosis.tools import cwl_insights, notion_get_page, notion_search
+from diagnosis.tools import cwl_insights, get_current_time, notion_get_page, notion_search
 
 
 def create_agent(config: DiagnosisConfig | None = None, session_id: str | None = None) -> Agent:
@@ -33,6 +33,6 @@ def create_agent(config: DiagnosisConfig | None = None, session_id: str | None =
     return Agent(
         model=model,
         system_prompt=SYSTEM_PROMPT,
-        tools=[notion_search, notion_get_page, cwl_insights],
+        tools=[notion_search, notion_get_page, cwl_insights, get_current_time],
         **kwargs,
     )

--- a/src/diagnosis/tools/__init__.py
+++ b/src/diagnosis/tools/__init__.py
@@ -1,5 +1,6 @@
+from diagnosis.tools.current_time import get_current_time
 from diagnosis.tools.cwl_insights import cwl_insights
 from diagnosis.tools.notion_get_page import notion_get_page
 from diagnosis.tools.notion_search import notion_search
 
-__all__ = ["cwl_insights", "notion_get_page", "notion_search"]
+__all__ = ["cwl_insights", "get_current_time", "notion_get_page", "notion_search"]

--- a/src/diagnosis/tools/current_time.py
+++ b/src/diagnosis/tools/current_time.py
@@ -1,0 +1,24 @@
+import json
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from strands import tool
+
+
+@tool
+def get_current_time() -> str:
+    """現在の日時を返す。cwl_insights の start_time/end_time を計算するときに使う。
+
+    Returns:
+        現在時刻をJSON文字列で返す。
+        {"unix_seconds": int, "utc": str, "jst": str}
+    """
+    now_utc = datetime.now(timezone.utc)
+    return json.dumps(
+        {
+            "unix_seconds": int(now_utc.timestamp()),
+            "utc": now_utc.isoformat(),
+            "jst": now_utc.astimezone(ZoneInfo("Asia/Tokyo")).isoformat(),
+        },
+        ensure_ascii=False,
+    )

--- a/tests/diagnosis/tools/test_current_time.py
+++ b/tests/diagnosis/tools/test_current_time.py
@@ -1,0 +1,69 @@
+import json
+
+
+def test_current_time_tool_exists():
+    from diagnosis.tools.current_time import get_current_time  # noqa: F401
+
+
+def test_current_time_is_strands_tool():
+    from diagnosis.tools.current_time import get_current_time
+    from strands.tools.decorator import DecoratedFunctionTool
+
+    assert isinstance(get_current_time, DecoratedFunctionTool)
+
+
+def test_current_time_returns_string():
+    from diagnosis.tools.current_time import get_current_time
+
+    result = get_current_time()
+    assert isinstance(result, str)
+
+
+def test_current_time_returns_valid_json():
+    from diagnosis.tools.current_time import get_current_time
+
+    result = get_current_time()
+    data = json.loads(result)
+    assert "unix_seconds" in data
+    assert "utc" in data
+    assert "jst" in data
+
+
+def test_current_time_unix_seconds_is_int():
+    from diagnosis.tools.current_time import get_current_time
+
+    result = get_current_time()
+    data = json.loads(result)
+    assert isinstance(data["unix_seconds"], int)
+
+
+def test_current_time_unix_seconds_is_reasonable():
+    """Unix秒が10桁（ミリ秒でない）であることを確認"""
+    import time
+
+    from diagnosis.tools.current_time import get_current_time
+
+    before = int(time.time())
+    result = get_current_time()
+    after = int(time.time())
+    data = json.loads(result)
+
+    assert before <= data["unix_seconds"] <= after
+    # 10桁であること（ミリ秒の13桁ではない）
+    assert len(str(data["unix_seconds"])) == 10
+
+
+def test_current_time_utc_contains_timezone():
+    from diagnosis.tools.current_time import get_current_time
+
+    result = get_current_time()
+    data = json.loads(result)
+    assert "+00:00" in data["utc"] or "Z" in data["utc"]
+
+
+def test_current_time_jst_contains_timezone():
+    from diagnosis.tools.current_time import get_current_time
+
+    result = get_current_time()
+    data = json.loads(result)
+    assert "+09:00" in data["jst"]


### PR DESCRIPTION
## Summary

- `src/diagnosis/tools/current_time.py` に `get_current_time` ツールを追加
- Unix秒・UTC・JSTの現在時刻をJSONで返す
- `agent.py` のツールリストに登録し、エージェントが自律的に呼び出せるようにした

## Test plan

- [x] `test_current_time_tool_exists` — モジュールのインポート確認
- [x] `test_current_time_is_strands_tool` — `@tool` デコレータ確認
- [x] `test_current_time_returns_valid_json` — JSON形式確認
- [x] `test_current_time_unix_seconds_is_reasonable` — Unix秒が10桁（ミリ秒でない）確認
- [x] `test_current_time_utc_contains_timezone` / `test_current_time_jst_contains_timezone` — タイムゾーン確認

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)