### PR TITLE
feat: 👀 リアクションで診断を開始する

### DIFF
--- a/slack_app_manifest.json
+++ b/slack_app_manifest.json
@@ -16,7 +16,8 @@
         "app_mentions:read",
         "chat:write",
         "channels:history",
-        "groups:history"
+        "groups:history",
+        "reactions:read"
       ]
     }
   },
@@ -24,7 +25,8 @@
     "event_subscriptions": {
       "request_url": "https://<API_GATEWAY_URL>/slack/events",
       "bot_events": [
-        "app_mention"
+        "app_mention",
+        "reaction_added"
       ]
     },
     "interactivity": {

--- a/src/slack_bot/app.py
+++ b/src/slack_bot/app.py
@@ -73,4 +73,38 @@ def process_mention(say, event, client) -> None:  # type: ignore[no-untyped-def]
     client.chat_update(channel=channel, ts=investigating_ts, text=result)
 
 
+def handle_reaction_added(ack) -> None:  # type: ignore[no-untyped-def]
+    """Slack の 3 秒タイムアウト回避のために即時 ACK を返す。"""
+    ack()
+
+
+def process_reaction_added(event, client, say) -> None:  # type: ignore[no-untyped-def]
+    """:eyes: リアクションを受けたメッセージを診断する (lazy listener で非同期実行)。"""
+    if event.get("reaction") != "eyes":
+        return
+
+    item = event["item"]
+    channel = item["channel"]
+    ts = item["ts"]
+
+    # リアクションされたメッセージ本文を取得
+    resp = client.conversations_history(channel=channel, latest=ts, limit=1, inclusive=True)
+    messages = resp.get("messages", [])
+    prompt = messages[0].get("text", "") if messages else ""
+
+    # 先に「調査中...」を投稿して ts を保存
+    posted = say(text="調査中...", thread_ts=ts)
+    investigating_ts = posted["ts"]
+
+    session_id = _make_session_id(channel, ts)
+    try:
+        result = _get_agent_client().invoke(prompt=prompt, session_id=session_id)
+    except Exception as exc:
+        logger.exception("AgentCore の呼び出しに失敗しました")
+        result = f"エラーが発生しました: {exc}"
+
+    client.chat_update(channel=channel, ts=investigating_ts, text=result)
+
+
 app.event("app_mention")(ack=handle_mention, lazy=[process_mention])
+app.event("reaction_added")(ack=handle_reaction_added, lazy=[process_reaction_added])

--- a/tests/slack_bot/test_app.py
+++ b/tests/slack_bot/test_app.py
@@ -138,3 +138,114 @@ def test_make_session_id_is_at_least_33_chars():
 
     session_id = _make_session_id("C123", "1234567890.123456")
     assert len(session_id) >= 33
+
+
+# --- reaction_added ハンドラのテスト ---
+
+
+def _make_reaction_event(reaction="eyes", channel="C123", ts="1234567890.123456"):
+    return {
+        "type": "reaction_added",
+        "user": "U456",
+        "reaction": reaction,
+        "item": {"type": "message", "channel": channel, "ts": ts},
+        "item_user": "U789",
+        "event_ts": "9999.000",
+    }
+
+
+def test_handle_reaction_added_calls_ack():
+    from slack_bot.app import handle_reaction_added
+
+    ack = MagicMock()
+    handle_reaction_added(ack)
+    ack.assert_called_once()
+
+
+def test_process_reaction_added_ignores_non_eyes_reaction():
+    from slack_bot.app import process_reaction_added
+
+    client = MagicMock()
+    say = MagicMock()
+
+    with patch("slack_bot.app._get_agent_client") as mock_get:
+        process_reaction_added(event=_make_reaction_event(reaction="thumbsup"), client=client, say=say)
+        mock_get.assert_not_called()
+
+    client.conversations_history.assert_not_called()
+
+
+def test_process_reaction_added_fetches_message_text():
+    from slack_bot.app import process_reaction_added
+
+    client = MagicMock()
+    client.conversations_history.return_value = {"messages": [{"text": "DBが重い", "ts": "1234567890.123456"}]}
+    say = MagicMock(return_value={"ts": "ts_investigating"})
+
+    with patch("slack_bot.app._get_agent_client") as mock_get:
+        agent_client = MagicMock()
+        agent_client.invoke.return_value = "診断結果"
+        mock_get.return_value = agent_client
+
+        process_reaction_added(event=_make_reaction_event(), client=client, say=say)
+
+    client.conversations_history.assert_called_once_with(
+        channel="C123", latest="1234567890.123456", limit=1, inclusive=True
+    )
+
+
+def test_process_reaction_added_posts_investigating_then_updates():
+    from slack_bot.app import process_reaction_added
+
+    client = MagicMock()
+    client.conversations_history.return_value = {"messages": [{"text": "DBが重い", "ts": "1234567890.123456"}]}
+    say = MagicMock(return_value={"ts": "ts_investigating"})
+
+    with patch("slack_bot.app._get_agent_client") as mock_get:
+        agent_client = MagicMock()
+        agent_client.invoke.return_value = "診断結果"
+        mock_get.return_value = agent_client
+
+        process_reaction_added(event=_make_reaction_event(), client=client, say=say)
+
+    say.assert_called_once_with(text="調査中...", thread_ts="1234567890.123456")
+    client.chat_update.assert_called_once()
+    call_kwargs = client.chat_update.call_args[1]
+    assert call_kwargs["text"] == "診断結果"
+    assert call_kwargs["ts"] == "ts_investigating"
+
+
+def test_process_reaction_added_invokes_agent_with_message_text():
+    from slack_bot.app import process_reaction_added
+
+    client = MagicMock()
+    client.conversations_history.return_value = {"messages": [{"text": "レイテンシが高い", "ts": "1234567890.123456"}]}
+    say = MagicMock(return_value={"ts": "ts_investigating"})
+
+    with patch("slack_bot.app._get_agent_client") as mock_get:
+        agent_client = MagicMock()
+        agent_client.invoke.return_value = "OK"
+        mock_get.return_value = agent_client
+
+        process_reaction_added(event=_make_reaction_event(), client=client, say=say)
+
+    call_kwargs = agent_client.invoke.call_args[1]
+    assert "レイテンシが高い" in call_kwargs["prompt"]
+
+
+def test_process_reaction_added_handles_agent_error_gracefully():
+    from slack_bot.app import process_reaction_added
+
+    client = MagicMock()
+    client.conversations_history.return_value = {"messages": [{"text": "エラー", "ts": "1234567890.123456"}]}
+    say = MagicMock(return_value={"ts": "ts_investigating"})
+
+    with patch("slack_bot.app._get_agent_client") as mock_get:
+        agent_client = MagicMock()
+        agent_client.invoke.side_effect = RuntimeError("connection failed")
+        mock_get.return_value = agent_client
+
+        process_reaction_added(event=_make_reaction_event(), client=client, say=say)
+
+    call_kwargs = client.chat_update.call_args[1]
+    assert "エラー" in call_kwargs["text"]


### PR DESCRIPTION
## Summary

- `reaction_added` イベントをハンドルし、`eyes` リアクション時のみ処理する
- `conversations_history` でリアクション先メッセージ本文を取得してAgentCoreを呼び出す
- 診断結果をリアクションされたメッセージのスレッドに返す
- メンション経由の既存フローは変更なし

## Test plan

- [ ] `handle_reaction_added` が ACK を返すこと
- [ ] `eyes` 以外のリアクションは無視されること
- [ ] `conversations_history` で正しいパラメータでメッセージを取得すること
- [ ] 「調査中...」→ 診断結果に更新されること
- [ ] エージェントがメッセージ本文で呼び出されること
- [ ] エラー時もクラッシュせずエラーメッセージを返すこと

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)